### PR TITLE
Fix CSV escaping for cells containing multiple double quotes by replacing all of them with the escaped form.

### DIFF
--- a/src/csv-builder/CsvBuilder.ts
+++ b/src/csv-builder/CsvBuilder.ts
@@ -34,7 +34,7 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
 
   private escapeCell(cellData: string): string {
     if(typeof cellData === 'string') {
-      return '"' + cellData.replace('"', '""') + '"';
+      return '"' + cellData.replace(/\"/g, '""') + '"';
     }
     return cellData;
   }


### PR DESCRIPTION
Javascript's `.replace()` function only replaces the first occurrence if the pattern is a string.