### PR TITLE
Add option to write the delimiter explicitly in CSV

### DIFF
--- a/src/csv-builder/CsvBuilder.ts
+++ b/src/csv-builder/CsvBuilder.ts
@@ -47,7 +47,7 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
     let dataArray:string[] = []; 
     
     if (explicitDelimiter) {
-      dataArray.push("sep=" + _Delimeter);
+      dataArray.push("sep=" + this._Delimeter);
     }
     
     if(this._Columns && this._Columns.length > 0) {

--- a/src/csv-builder/CsvBuilder.ts
+++ b/src/csv-builder/CsvBuilder.ts
@@ -6,10 +6,12 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
   private _Delimeter: string = ',';
   private _Columns: string[] = [];
   private _RowData: string[][] = [];
+  private _ExplicitDelimiter: boolean = false;
 
-  constructor(fileName: string) {
+  constructor(fileName: string, explicitDelimiter = false) {
     super();
     this._FileName = fileName;
+    this._ExplicitDelimiter = explicitDelimiter;
   }
 
   public setColumns(columns: string[]): CsvBuilder {
@@ -43,10 +45,10 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
     return row.map(this.escapeCell).join(this._Delimeter);
   }
 
-  public exportFile(explicitDelimiter = false): void {
+  public exportFile(): void {
     let dataArray:string[] = []; 
     
-    if (explicitDelimiter) {
+    if (this._ExplicitDelimiter) {
       dataArray.push("sep=" + this._Delimeter);
     }
     

--- a/src/csv-builder/CsvBuilder.ts
+++ b/src/csv-builder/CsvBuilder.ts
@@ -43,8 +43,13 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
     return row.map(this.escapeCell).join(this._Delimeter);
   }
 
-  public exportFile(): void {
-    let dataArray:string[] = [];    
+  public exportFile({explicitDelimiter: boolean} = {explicitDelimiter: false}): void {
+    let dataArray:string[] = []; 
+    
+    if (explicitDelimiter) {
+      dataArray.push("sep=" + _Delimeter);
+    }
+    
     if(this._Columns && this._Columns.length > 0) {
       dataArray.push(this.getRowData(this._Columns));
     }

--- a/src/csv-builder/CsvBuilder.ts
+++ b/src/csv-builder/CsvBuilder.ts
@@ -43,7 +43,7 @@ export default class CsvBuilder extends BaseBuilder implements IFileExporter {
     return row.map(this.escapeCell).join(this._Delimeter);
   }
 
-  public exportFile({explicitDelimiter: boolean} = {explicitDelimiter: false}): void {
+  public exportFile(explicitDelimiter = false): void {
     let dataArray:string[] = []; 
     
     if (explicitDelimiter) {


### PR DESCRIPTION
Hi, Excel shows a different version of the .csv file in different regions.
On some computers it's better to use the comma, on others the semicolon. 

By explicitly writing the delimiter we avoid this problem. 

I know it seems like a Excel specific fix, but Excel is very popular and I made intentionaly the parameter optional so we avoid the necessity to specify it.

https://stackoverflow.com/questions/17953679/how-to-correctly-display-csv-files-within-excel-2013#19769403