### PR TITLE
Add TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filefy",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A javascript library to produce downloadable files sucs as in CSV, PDF, XLSX, DOCX formats",
   "main": "./dist/index.js",
   "homepage": "https://github.com/mbrn/filefy#readme",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "./dist",
     "target": "es5",
     "module": "commonjs",
+    "declaration": true,
     "strict": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
Add TypeScript typings to tsconfig.json so TypeScript can be used with this repository without the need to create a separate typings file.